### PR TITLE
Cycles text color no longer hardcoded to yellow

### DIFF
--- a/source/PmmEdit/codeeditor.cpp
+++ b/source/PmmEdit/codeeditor.cpp
@@ -414,7 +414,7 @@ void CodeEditor::cycleNumberAreaPaintEvent(QPaintEvent *event)
             {
 
                 QString number = QString::number(m_cycles[ln]);
-                painter.setPen(Qt::yellow);
+                painter.setPen(cyclesColor);
                 painter.drawText(0, top, cycleNumberArea->width(), fontMetrics().height(),
                              Qt::AlignLeft, number);
             }


### PR DESCRIPTION
Missed spot where text color is set for no. of cycles (actual integer value), it was hardcoded to yellow. This fix will follow theme setting.