### PR TITLE
Add VIARasterIRQ() for VIC-20 raster interrupts

### DIFF
--- a/resources/text/syntax.txt
+++ b/resources/text/syntax.txt
@@ -385,6 +385,7 @@ m; DisableVIC20IRQ; VIC20;
 #m; StartVIAIRQ; VIC20;
 #m; CloseVIAIRQ; VIC20;
 m; VIAIRQ; VIC20; p,b,b
+m; VIARasterIRQ; VIC20; p,b,b
 
 
 

--- a/source/Compiler/assembler/methods6502.cpp
+++ b/source/Compiler/assembler/methods6502.cpp
@@ -497,6 +497,8 @@ void Methods6502::Assemble(Assembler *as, AbstractASTDispatcher* dispatcher) {
     if (Command("VIAIRQ"))
         VIAIRQ(as);
 
+    if (Command("VIARasterIRQ"))
+        VIARasterIRQ(as);
 
     if (Command("CreateInteger"))
         CreateInteger(as,"y");
@@ -13639,9 +13641,44 @@ void Methods6502::VIAIRQ(Assembler *as)
     as->Term();
     as->Asm("sta timers_vic_raster+3");
 
-
+    as->Asm("ldx #0"); // Start timer from raster line 0
     as->Asm("jsr init_via_irq");
 }
+
+void Methods6502::VIARasterIRQ(Assembler *as)
+{
+    NodeProcedure* addr = (NodeProcedure*)dynamic_cast<NodeProcedure*>(m_node->m_params[0]);
+    QString name = addr->m_procedure->m_procName;
+    m_node->RequireNumber(m_node->m_params[2], "RasterIRQ", m_node->m_op.m_lineNumber);
+
+    as->Asm("lda #<"+name);
+    as->Asm("sta pointers_vic_raster+1");
+    as->Asm("lda #>"+name);
+    as->Asm("sta pointers_vic_raster+6");
+
+    LoadVar(as,1);
+    as->Asm("tax");
+
+    LoadVar(as,2);
+    as->Asm("cmp #0");
+    as->Asm("bne viarasterirq_ntsc_timing");
+    as->Asm("lda #$86");
+    as->Asm("sta timers_vic_raster+1");
+    as->Asm("lda #$56");
+    as->Asm("sta timers_vic_raster+3");
+    as->Asm("jsr A0_vic_raster");
+    as->Asm("jmp viarasterirq_end");
+
+    as->Label("viarasterirq_ntsc_timing");
+    as->Asm("lda #$43");
+    as->Asm("sta timers_vic_raster+1");
+    as->Asm("lda #$42");
+    as->Asm("sta timers_vic_raster+3");
+    as->Asm("jsr A0_vic_raster");
+
+    as->Label("viarasterirq_end");
+}
+
 
 void Methods6502::InitVIAIRQ(Assembler *as)
 {

--- a/source/Compiler/assembler/methods6502.cpp
+++ b/source/Compiler/assembler/methods6502.cpp
@@ -13659,24 +13659,27 @@ void Methods6502::VIARasterIRQ(Assembler *as)
     LoadVar(as,1);
     as->Asm("tax");
 
+    QString lbl1 = as->NewLabel("viarasterirq_ntsc_timing");
+    QString lbl2 = as->NewLabel("viarasterirq_end");
+
     LoadVar(as,2);
     as->Asm("cmp #0");
-    as->Asm("bne viarasterirq_ntsc_timing");
+    as->Asm("bne " + lbl1);
     as->Asm("lda #$86");
     as->Asm("sta timers_vic_raster+1");
     as->Asm("lda #$56");
     as->Asm("sta timers_vic_raster+3");
     as->Asm("jsr A0_vic_raster");
-    as->Asm("jmp viarasterirq_end");
+    as->Asm("jmp " + lbl2);
 
-    as->Label("viarasterirq_ntsc_timing");
+    as->Label(lbl1);
     as->Asm("lda #$43");
     as->Asm("sta timers_vic_raster+1");
     as->Asm("lda #$42");
     as->Asm("sta timers_vic_raster+3");
     as->Asm("jsr A0_vic_raster");
 
-    as->Label("viarasterirq_end");
+    as->Label(lbl2);
 }
 
 

--- a/source/Compiler/assembler/methods6502.h
+++ b/source/Compiler/assembler/methods6502.h
@@ -117,6 +117,7 @@ public:
 //    void EnableInterrupts(Assembler* as);
     void RasterIRQ(Assembler* as);
     void VIAIRQ(Assembler* as);
+    void VIARasterIRQ(Assembler* as);
     void InitVIAIRQ(Assembler* as);
     void RasterIRQWedge(Assembler* as);
     void ClearScreen(Assembler* as);

--- a/source/Compiler/parser.cpp
+++ b/source/Compiler/parser.cpp
@@ -159,6 +159,7 @@ void Parser::InitBuiltinFunctions()
         InitBuiltinFunction(QStringList()<< "rasterirqwedge(" , "init_wedge");
         InitBuiltinFunction(QStringList()<< "playvic20sid(" , "init_vic20_sidplay");
         InitBuiltinFunction(QStringList()<< "viairq(" , "init_viairq");
+        InitBuiltinFunction(QStringList()<< "viarasterirq(" , "init_viairq");
         InitBuiltinFunction(QStringList()<< "initmodplayer(" , "include_modplayer");
         InitBuiltinFunction(QStringList()<< "decrunch("<<"decrunchfromindex(", "init_decrunch");
 


### PR DESCRIPTION
VIARasterIRQ() method added that takes 3 params: function, rasterline and pal/ntsc (0/1).

I will add help-texts as separate PR.