### PR TITLE
Feature: Store and restore IDE window size

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -23,6 +23,7 @@
 #include "mainwindow.h"
 #include <QApplication>
 #include <QStyleFactory>
+#include <QSettings>
 
 void ConvertPerlin(QString input, QString out, float div) {
     QImage img;
@@ -140,6 +141,11 @@ int main(int argc, char *argv[])
         w.m_commandParams+=QString(argv[i]);
     w.showMaximized();
     w.AfterStart(oldCurDir);
+
+    qDebug() << "Restore settings";
+    QSettings settings("LemonSpawn", "TRSE");
+    w.restoreGeometry(settings.value("MainWindow/geometry").toByteArray());
+    w.restoreState(settings.value("MainWindow/windowState").toByteArray());
 
     return a.exec();
 }

--- a/main.cpp
+++ b/main.cpp
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
     MainWindow w;
     for (int i=0;i<argc;i++)
         w.m_commandParams+=QString(argv[i]);
-    w.showMaximized();
+    w.show();
     w.AfterStart(oldCurDir);
 
     qDebug() << "Restore settings";

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -36,6 +36,7 @@
 #include "source/dialogabout.h"
 #include "source/LeLib/limage/limageio.h"
 #include <QMessageBox>
+#include <QSettings>
 #include "source/Compiler/assembler/mos6502.h"
 #include "source/dialogeffects.h"
 #include "source/Compiler/errorhandler.h"
@@ -615,8 +616,13 @@ QString MainWindow::getProjectPath()
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
-    if (CloseAll())
+    if (CloseAll()) {
+        qDebug() << "Store settings";
+        QSettings settings("LemonSpawn", "TRSE");
+        settings.setValue("MainWindow/geometry", saveGeometry());
+        settings.setValue("MainWindow/windowState", saveState());
         event->accept();
+    }
     else
         event->ignore();
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -62,7 +62,6 @@
 
 namespace Ui {
 class MainWindow;
-
 }
 
 


### PR DESCRIPTION
Something has been bothering me a while, which is, when opening TRSE, the window size and location is not remembered, instead it opens just maximized window. I'm using 28" monitor with high DPI and want to use multiple windows on same screen and resizing window is always tedious. 

This is suggested patch to remember user-set window size and location in TRSE. 