### PR TITLE
Fix building on MacOS

### DIFF
--- a/TRSE.pro
+++ b/TRSE.pro
@@ -4,9 +4,9 @@
 #
 #-------------------------------------------------
 
-QT       += core gui opengl qml
+QT += core gui opengl qml
 QT += widgets
-
+CONFIG += c++14
 
 TARGET = trse
 TEMPLATE = app


### PR DESCRIPTION
It seems Clang isn't that forgiving as GCC, while using the C++14 features. By default QMake sets the C++11 as a standard, but using auto in lambdas requires C++14 and Clang barfs without this setting.
