### PR TITLE
Typo ("unexplanded")

### DIFF
--- a/resources/text/help/p/screen.rtf
+++ b/resources/text/help/p/screen.rtf
@@ -37,7 +37,7 @@ begin
 <p>Note that on the Vic20, after setting the screenmemory pointer, SetColorAddr(); can be used to set the equivalent address in the colour memory. This is a shortcut and fast command. </p>
 <ul>
     <li>$1E00 = Default screen memory address for the unexpanded Vic</li>
-    <li>$9600 = Default color memory address for the unexplanded Vic</li>
+    <li>$9600 = Default color memory address for the unexpanded Vic</li>
 </ul>
 <ul>
     <li>$1000 = Default screen memory address for the 8k+ Vic</li>


### PR DESCRIPTION
> unexplanded

to

> unexpanded