### PR TITLE
Attempt to fix the off-center splash screen on windows

### DIFF
--- a/source/dialogsplash.cpp
+++ b/source/dialogsplash.cpp
@@ -26,7 +26,9 @@ DialogSplash::DialogSplash(QWidget *parent) :
 
 
     ui->lblText->setText(texts[rand()%texts.count()]);
-
+    // -- Bones: Trying to fix the off-center spash screen on windows
+    const QRect screen = parent->geometry();
+        this->move( screen.center() );
 
 }
 


### PR DESCRIPTION
Setting the position to the center of parent on start.

![image](https://user-images.githubusercontent.com/36438870/104805844-e0b68380-57ca-11eb-9216-ad794daf3833.png)


![image](https://user-images.githubusercontent.com/36438870/104805819-ad73f480-57ca-11eb-86d2-407ee6135c7b.png)
