### PR TITLE
Calculates the correct data for the BASIC stub

### DIFF
--- a/source/Compiler/assembler/mos6502/mos6502.cpp
+++ b/source/Compiler/assembler/mos6502/mos6502.cpp
@@ -179,10 +179,22 @@ void AsmMOS6502::Program(QString programName, QString vicConfig)
 
         }
         else {
+
+            // new method
+            Asm(".byte $00 ; fill $xxx0");
+            Asm( ".byte $" + QString::number( (Syntax::s.m_currentSystem->m_startAddress + 10) & 0x0ff, 16  ) + " ; lo byte of next line" );
+            Asm( ".byte $" + QString::number( ( (Syntax::s.m_currentSystem->m_startAddress + 10) & 0x0ff00 ) >> 8, 16 ) + " ; hi byte of next line" );
+            Asm(".byte $0a ; line 10");
+            Asm(".byte $00, $9e, $20 ; SYS token");
+            // write PETSCII / ASCII representation of address to call
+            Asm(intToHexString(Syntax::s.m_currentSystem->m_programStartAddress));
+            Asm(".byte $00, $00, $00 ; end of program");
+
+            /* // old method
             Asm(".byte    $0, $0E, $08, $0A, $00, $9E, $20");
             Asm(intToHexString(Syntax::s.m_currentSystem->m_programStartAddress));
-            Asm(".byte     $00");   // 6, 4, )*/
-
+            Asm(".byte     $00");   // 6, 4, )
+            */
             Nl();
             }
         EndMemoryBlock();


### PR DESCRIPTION
The BASIC stub is now created correctly. I have tested on PET, Vic and C64. The two corrections are:

1. The address on the next line in BASIC is calculated correctly
2. The end of program is terminated correctly (extra zeros)

I've also commented the component part.

The new code is as follows:

### mos6502.cpp

```
            // new method
            Asm(".byte $00 ; fill $xxx0");
            Asm( ".byte $" + QString::number( (Syntax::s.m_currentSystem->m_startAddress + 10) & 0x0ff, 16  ) + " ; lo byte of next line" );
            Asm( ".byte $" + QString::number( ( (Syntax::s.m_currentSystem->m_startAddress + 10) & 0x0ff00 ) >> 8, 16 ) + " ; hi byte of next line" );
            Asm(".byte $0a ; line 10");
            Asm(".byte $00, $9e, $20 ; SYS token");
            // write PETSCII / ASCII representation of address to call
            Asm(intToHexString(Syntax::s.m_currentSystem->m_programStartAddress));
            Asm(".byte $00, $00, $00 ; end of program");
```

- The ZERO at address $0400, or $1000, or $0800 is present. Not addressing that one in this pull request, so works same as before.
- Next are two bytes that point to the start address + 10. This is the address in memory where the next line will start
- then $0a = 10 or line 10 
- $00 (need a pad) $9e (the SYS token) and $20 (space)
- ASCII bytes to represent the sys address to call, eg: 1234 would need four ascii bytes representing numbers 0-9
- finally three $00 bytes - I think only need two but padding out

Tested with program start address low to high values. Eg: 32952 (five digits) works ok.

Please review.