### PR TITLE
Ignore most generated files on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
-
+*.o
+moc_*.cpp
+ui_*.h
+Makefile
+trse
 TRSE.pro.user
 Publish/tutorials/C64/Tutorials/.backup/units_00_keyboard_unit.ras/backup_Fri Feb 5 21_53_09 2021.bak


### PR DESCRIPTION
Add some generated files that are polluting git status output on linux.
Please confirm that it's OK to consider `moc_` and `ui_` prefixes as reserved for generated files.