### PR TITLE
Bugfix: Shift-tab

### DIFF
--- a/source/PmmEdit/codeeditor.cpp
+++ b/source/PmmEdit/codeeditor.cpp
@@ -290,8 +290,7 @@ void CodeEditor::keyPressEvent(QKeyEvent *e)
         FixBackTab(e);
 //        QPlainTextEdit::keyPressEvent(e);
 //        return;
-//        e->ignore();
-      //  return;
+        return;
     }
     if (!(c && c->popup()->isVisible()))
     if (e->key()==Qt::Key_Return ) {


### PR DESCRIPTION
This fixes bug where shift-tab in editor also changes active UI element.

Fix is simple, just return from keyPressEvent() after handling Key_Backtab.