### PR TITLE
Allow spaces in PRG path for user defined tool (CTRL+T)

### DIFF
--- a/source/trsedocuments/trsedocument.cpp
+++ b/source/trsedocuments/trsedocument.cpp
@@ -133,11 +133,12 @@ void TRSEDocument::UserDefined()
         if (m_projectIniFile->getString("main_ras_file")!=m_currentFileShort)
             src = m_currentDir+ m_projectIniFile->getString("main_ras_file");
 
-
-
-    paramsStr = paramsStr.replace("@prg", src.replace(".ras", "."+m_programEndingType)).trimmed();
     QStringList params = paramsStr.split(" ");
-    p.startDetached(cmd,params);
+    for (auto& param : params) {
+        if (param.startsWith("@prg"))
+            param = param.replace("@prg", src.replace(".ras", "."+m_programEndingType)).trimmed();
+    }
+    p.startDetached(cmd, params);
     p.waitForFinished();
 
 }


### PR DESCRIPTION
Replacing `@prg` with prg file path, and then splitting it to parameters with a space key delimiter resulted in more (broken) parameters. i.e. with "D:\Documents\My TRSE Projects\main.prg" second parameter became "D:\Documents\My" instead of complete prg path.
This fix splits user-defined parameters first, then applies any changes to them (well there is only one at the moment - `@prg`).
Tested on Windows, please test it on other platforms.

Also i believe this feature could be expanded with more variables - like platform type, so the user-defined tool can process files properly without guessing a platform type from a file start address etc. (i.e. VIC-20 vs C64)