### PR TITLE
Set80ColumnMode() OR -> ORA

### DIFF
--- a/units/MEGA65/screen.tru
+++ b/units/MEGA65/screen.tru
@@ -56,7 +56,7 @@ procedure Set80ColumnMode() inline;
 begin
 	asm("
 		lda $D031
-		or #%10000000
+		ora #%10000000
 		sta $d031
 	");
 end;


### PR DESCRIPTION
OR doesn't compile on CL65, ORA does.

Fixes #677 