### PR TITLE
Added Target None to CL65 commandline params

### DIFF
--- a/source/Compiler/systems/system65c816.cpp
+++ b/source/Compiler/systems/system65c816.cpp
@@ -33,7 +33,7 @@ void System65C816::Assemble(QString &text, QString filename, QString currentDir,
         QString smc = currentDir + QDir::separator() + "config.cfg";
 //        if (!QFile::exists(smc))
             Util::CopyFile(":resources/code/mega65/config.cfg",smc);
-        QStringList params = QStringList() <<"-C" <<smc <<"--start-addr"<< "$2020"<<("-o"+filename+".prg") <<(filename +".asm") ;
+        QStringList params = QStringList() << "-t none" << "-C" <<smc <<"--start-addr"<< "$2020"<<("-o"+filename+".prg") <<(filename +".asm") ;
 //        QStringList params = QStringList() <<"--cpu"<<"4510"<<(filename +".asm") <<("-o"+filename+".prg");
         AssembleCL65(text,filename,currentDir,symTab,"prg",params);
 


### PR DESCRIPTION
CL65 defaults to -target C64, which does its own asciiz character manipulation. Target none leaves asciiz strings as is, and we can do our own modification in the printstring function. This fixes inverted text.

Fixes #679 