### PR TITLE
Fixed load and store on Chip-8.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ Publish/tutorials/**/*.prg
 #Publish/tutorials/**/*.chr
 #Publish/tutorials/**/*.dat
 .DS_Store
+.qmake.stash

--- a/source/Compiler/codegen/codegen_chip8.cpp
+++ b/source/Compiler/codegen/codegen_chip8.cpp
@@ -270,27 +270,34 @@ QString CodeGenChip8::getReg(int dd) {
 void CodeGenChip8::ldr(QString x0, QString x1)
 {
     as->Asm("ld I,"+x1);
-    as->Asm("ld "+x0+",[I]");
+    as->Asm("ld V0, [I]");
+    if (x0 != "V0") as->Asm("ld "+x0+", V0");
 }
 
 void CodeGenChip8::str(QString x0, QString x1)
 {
     as->Asm("ld I,"+x1);
-
-    as->Asm("ld [I],"+x0);
+    if (x0 != "V0") as->Asm("ld V0, "+x0);
+    as->Asm("ld [I], V0");
 }
 
 void CodeGenChip8::str(QSharedPointer<Node> var)
 {
     if (var->isWord(as)) {
-/*        QString x0 = getReg();
-        QString x1 = m_regs[m_lvl+1];
-        as->Asm("ld ["+var->getValue(as)+"],"+x0+","+x1);*/
+        QString x0 = getReg();
+        QString x1 = getReg();
+        as->Asm("LD I, "+var->getValue(as));
+        if (x0!="V0") as->Asm("ld V0, "+x0);
+        if (x1!="V1") as->Asm("ld V1, "+x1);
+        as->Asm("LD [I], V1");
+
     }
     else {
         QString x0 = getReg();
         as->Asm("ld I,"+var->getValue(as));
-        as->Asm("ld [I],"+x0);
+        if (x0!="V0") as->Asm("ld V0, "+x0);
+        
+        as->Asm("ld [I], V0");
 
     }
 }
@@ -311,13 +318,19 @@ void CodeGenChip8::ldr(QSharedPointer<Node> var)
 */
     if (var->isWord(as)) {
         QString x0 = getReg();
-        QString x1 = m_regs[m_lvl+1];
-        as->Asm("lw16 "+x0+","+x1+ ", ["+var->getValue(as)+"]");
+        QString x1 = getReg();
+        as->Asm("ld I,"+var->getValue(as));
+        as->Asm("LD V1, [I]");
+        if (x0!="V0") as->Asm("ld "+x0+", V0");
+        if (x1!="V1") as->Asm("ld "+x1+", V1");
+        
     }
     else {
         QString x0 = getReg();
         as->Asm("ld I,"+var->getValue(as));
-        as->Asm("ld "+x0+",[I]");
+        as->Asm("ld V0,[I]");
+        if (x0!="V0") as->Asm("ld "+x0+",V0");
+        
 
     }
 

--- a/units/CHIP8/system/system.tru
+++ b/units/CHIP8/system/system.tru
@@ -7,7 +7,7 @@ begin
 	asm("cls");
 end;
 
-function Random() : byte;
+function Random() inline : byte;
 begin
 	asm("
 		RND V0, #FF
@@ -50,14 +50,9 @@ begin
     ");
 end;
 
-function WaitForKey(): byte;
+function WaitForKey() inline : byte;
 begin
-    asm("
-        LD I, System_result
-        LD V0, K
-        LD [I], V0
-    ");
-    WaitForKey := result;
+    asm("LD V0, K");
 end;
 
 procedure setDT(x : global byte);
@@ -70,14 +65,9 @@ begin
 
 end;
 
-function getDT() : byte;
+function getDT() inline : byte;
 begin
-    asm("
-        LD I, System_result
-        LD V0, DT
-        LD [I], V0
-    ");
-    getDT := result;
+    asm("LD V0, DT");
 
 end;
 
@@ -90,10 +80,7 @@ begin
         SKNP V0
         LD V1, 1
         LD V0, V1
-        LD I,result
-        LD [I], V0
     ");
-    isKeydown := result;
 end;
 
 end.

--- a/units/CHIP8/system/system.tru
+++ b/units/CHIP8/system/system.tru
@@ -1,6 +1,6 @@
 unit System;
 var
-	val,x,y,line,c,result : byte; 
+	val,x,y,c : byte; 
 
 procedure Clear() inline;
 begin
@@ -13,12 +13,12 @@ begin
 		RND V0, #FF
 	");
 end;
-procedure DrawLine(x,y,line:global byte);
+procedure DrawLine(x,y,c:global byte);
 begin 
     asm("
         LD I, System_x
         LD V1, [I]
-        LD I, System_line
+        LD I, System_c
         DRW V0, V1, 1
     ");
 end;


### PR DESCRIPTION
Load store in Chip-8 acts more like ARM's LDM and STM.

From Cowgod's Documentation 

"
Fx55 - LD [I], Vx
Store registers V0 through Vx in memory starting at location I.

The interpreter copies the values of registers V0 through Vx into memory, starting at the address in I.

Fx65 - LD Vx, [I]
Read registers V0 through Vx from memory starting at location I.

The interpreter reads values from memory starting at location I into registers V0 through Vx.
"

I also added word loads and stores. Chip-8 is big endian so LD V1, [I] puts the high byte in V0 and the low byte in V1 and vica versa for stores. 

Edit: Oh I made an assumption in the library that the arguments are sequential in memory and you were unaware of it (due to the same weird load store semantics). I fixed it now. 