### PR TITLE
Fix Atari 800 tab40

### DIFF
--- a/units/ATARI800/screen.tru
+++ b/units/ATARI800/screen.tru
@@ -2,7 +2,7 @@ unit Screen;
 var
 	sp,tp : pointer;
 	x,y,i,j : byte;
-	tab40 : array[screen_height] of byte = BuildTable("i*40");
+	tab40 : array[screen_height] of integer = BuildTable("i*40");
 /**
 	Returns the screen pointer 
 **/


### PR DESCRIPTION
Current tab40 is an array of bytes, causing it to overflow and place strings erroneously over Y values of 6.