### PR TITLE
Fix nightly builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Ideally we would like to do it once for all builds,
       # but this is complicated as we want to allow to trigger a nightly by
       # pushing the tag, so this can't be in nightly.yml. One option would be to
@@ -23,7 +23,7 @@ jobs:
           let version=${version}+1
           sed -i "s/define NIGHTLY .*/define NIGHTLY $version/" source/LeLib/data.cpp
           version=$(grep "define \(MAJOR\|FEATURE\|NIGHTLY\)" source/LeLib/data.cpp | awk '{ print $3 }' | xargs | sed 's/ /\./g')
-          echo "::set-output name=TRSE_VERSION::${version}"
+          echo "TRSE_VERSION=${version}" >> $GITHUB_OUTPUT
       - name: Commit & Push new version
         uses: actions-js/push@master
         with:
@@ -36,9 +36,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install qtbase5-dev qt5-qmake qtdeclarative5-dev
           # For 'Verify all' tests
-          # dbus-x11, at-spi2-core, libavformat58, libswscale5 and libswresample3 seem to be required by vice yet not pulled by its package
+          # dbus-x11, at-spi2-core, libavformat-dev, libswscale-dev and libswresample-dev seem to be required by vice yet not pulled by its package
           # libsdl2-dev, libfreetype6-dev, zlib1g-dev and libpng-dev are needed to build Caprice32
-          sudo apt-get install lz4 python3 xvfb vice dosbox nasm dbus-x11 at-spi2-core libavformat58 libswscale5 libswresample3 libsdl2-dev libfreetype6-dev zlib1g-dev libpng-dev
+          sudo apt-get install lz4 python3 xvfb vice dosbox nasm dbus-x11 at-spi2-core libavformat-dev libswscale-dev libswresample-dev libsdl2-dev libfreetype6-dev zlib1g-dev libpng-dev
 
       - name: Build and configure assemblers and emulators (vasm, rgbasm, VICE, cap32)
         run: |
@@ -134,13 +134,13 @@ jobs:
       - name: Build tar.gz
         run: cd Publish/publish_linux && ./publish nightly
       - name: Publish tar.gz
-        uses: ColinPitrat/update-release@master
+        uses: softprops/action-gh-release@v2
         with:
-          release: nightly
-          message: Nightly build
+          name: nightly
           body: TRSE ${{ steps.version.outputs.TRSE_VERSION }} <br/> The latest automated nightly build of TRSE which succeeded. This is the recommended version to use.
           files: Publish/publish_linux/trse_linux64.tar.gz
           prerelease: false
+          make_latest: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify tutorials

--- a/.github/workflows/macx.yml
+++ b/.github/workflows/macx.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Increment version. Ideally we would like to do it once for all builds,
       # but this is complicated as we want to allow to trigger a nightly by
       # pushing the tag, so this can't be in nightly.yml. One option would be to
@@ -25,9 +25,9 @@ jobs:
           # backup file, empty string disables backup)
           sed -i '' "s/define NIGHTLY .*/define NIGHTLY $version/" source/LeLib/data.cpp
           version=$(grep "define \(MAJOR\|FEATURE\|NIGHTLY\)" source/LeLib/data.cpp | awk '{ print $3 }' | xargs | sed 's/ /\./g')
-          echo "::set-output name=TRSE_VERSION::${version}"
+          echo "TRSE_VERSION=${version}" >> $GITHUB_OUTPUT
       - uses: actions/setup-node@v4
-      - uses: jurplel/install-qt-action@v3
+      - uses: jurplel/install-qt-action@v4
         with:
           aqtversion: '==3.1.*'
           version: '6.6.0'
@@ -53,13 +53,13 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k hurra build.keychain
           security find-identity -v
           cd Publish/publish_mac && ./publish_mac.sh nightly $DEVELOPER_ID
-      - uses: ColinPitrat/update-release@master
+      - uses: softprops/action-gh-release@v2
         with:
-          release: nightly
-          message: Nightly build
+          name: nightly
           body: TRSE ${{ steps.version.outputs.TRSE_VERSION }} <br/> The latest automated nightly build of TRSE which succeeded. This is the recommended version to use.
           files: Publish/publish_mac/trse_osx.tar.gz
           prerelease: false
+          make_latest: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build notification

--- a/.github/workflows/win32-msvc.yml
+++ b/.github/workflows/win32-msvc.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-2019
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # Increment version. Ideally we would like to do it once for all builds,
       # but this is complicated as we want to allow to trigger a nightly by
       # pushing the tag, so this can't be in nightly.yml. One option would be to
@@ -25,13 +25,13 @@ jobs:
           let version=${version}+1
           sed -i "s/define NIGHTLY .*/define NIGHTLY $version/" source/LeLib/data.cpp
           version=$(grep "define \(MAJOR\|FEATURE\|NIGHTLY\)" source/LeLib/data.cpp | awk '{ print $3 }' | xargs | sed 's/ /\./g')
-          echo "::set-output name=TRSE_VERSION::${version}"
-      - uses: microsoft/setup-msbuild@v1
+          echo "TRSE_VERSION=${version}" >> $GITHUB_OUTPUT
+      - uses: microsoft/setup-msbuild@v2
 
-      - uses: jurplel/install-qt-action@v2
+      - uses: jurplel/install-qt-action@v4
         with:
           version: '6.0.1'
-          tools: 'tools_ifw,4.0.0,qt.tools.ifw.40 tools_qtcreator,9.0.0,qt.tools.qtcreator'
+          tools: 'tools_ifw tools_qtcreator,qt.tools.qtcreator'
 
 
       - name: Build TRSE
@@ -104,13 +104,13 @@ jobs:
           7z a trse_win.zip trse
 
       - name: Publish zip
-        uses: ColinPitrat/update-release@master
+        uses: softprops/action-gh-release@v2
         with:
-          release: nightly
-          message: Nightly build
+          name: nightly
           body: TRSE ${{ steps.version.outputs.TRSE_VERSION }} <br/> The latest automated nightly build of TRSE which succeeded. This is the recommended version to use.
           files: Publish/publish_win/trse_win.zip
           prerelease: false
+          make_latest: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build notification

--- a/source/LeLib/data.cpp
+++ b/source/LeLib/data.cpp
@@ -28,7 +28,7 @@
 
 #define MAJOR 0
 #define FEATURE 18
-#define NIGHTLY 47
+#define NIGHTLY 48
 
 #define VERSION STR(MAJOR) "." STR(FEATURE) "." STR(NIGHTLY)
 


### PR DESCRIPTION
@ghostsoft noticed the [nightly downloads](https://lemonspawn.com/turbo-rascal-syntax-error-expected-but-begin/downloads/) weren't working, so I updated all the failing GH actions to fix them.

Example: https://github.com/SupSuper/TRSE/releases/tag/nightly

Not sure why build failures remove the last download though, would be nice if old versions were kept around.