### PR TITLE
Fix that prevents linux buiding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Makefile
 trse
 TRSE.pro.user
 w_*.tru
+build
 
 Publish/tutorials/C64/Tutorials/.backup/units_00_keyboard_unit.ras/backup_Fri Feb 5 21_53_09 2021.bak
 

--- a/source/LeLib/limage/limagethomson.h
+++ b/source/LeLib/limage/limagethomson.h
@@ -1,5 +1,5 @@
 #ifndef LIMAGETHOMSON_H
-#define LIMAGETHOMSOM_H
+#define LIMAGETHOMSON_H
 
 #include "limageqimage.h"
 #include <QMatrix4x4>

--- a/source/LeLib/util/tool.cpp
+++ b/source/LeLib/util/tool.cpp
@@ -41,13 +41,13 @@ bool Tool::AKGCompiler(QString filename, int Address, SymbolTable *symTab)
     Util::CopyFile(":resources/bin/rasm_osx",rasm);
     QFile::setPermissions(rasm,QFile::ExeUser);
 #endif
-#ifdef defined(Q_OS_FREEBSD)
+/*#ifdef defined(Q_OS_FREEBSD)
     QString rasm = path+"rasm";
     Util::CopyFile(":resources/bin/rasm",rasm);
     QFile::setPermissions(rasm,QFile::ExeUser);
 
 #endif
-
+*/
     Util::CopyFile(":resources/code/amstrad/playerakg.asm",player);
     Util::CopyFile(":resources/code/amstrad/playerakg_soundeffects.asm",snd);
 

--- a/source/OrgAsm/orgasm68k.h
+++ b/source/OrgAsm/orgasm68k.h
@@ -1,5 +1,5 @@
 #ifndef ORGASM68k_H
-#define ORGAsm68k_H
+#define ORGASM68k_H
 
 
 #include "orgasm.h"

--- a/source/chip8emu/c8asm.c
+++ b/source/chip8emu/c8asm.c
@@ -232,7 +232,7 @@ static int get_base(const char * a){
     else
         return 0;
 }
-static int parse_int(const char ** expression,const int linenum){
+static int parse_int(/*const*/ char ** expression,const int linenum){
     int base = get_base(*expression);
     if(base <= 0)
         exit_error("error%d: Invalid Immediate\n", linenum);
@@ -301,7 +301,7 @@ static  int apply_binary_op(const  int l_op, const char op, const  int r_op, con
     return -1;
 
 }
-static int evaluate_arithmetic_expression(const char * expression, const int linenum){
+static int evaluate_arithmetic_expression(/*const*/ char * expression, const int linenum){
 
     struct {unsigned char stack[STACK_HEIGHT]; unsigned char * top;} operators; operators.top=operators.stack-1;
     struct {int stack[STACK_HEIGHT]; int *top;} figures;


### PR DESCRIPTION
const in parse_int causes error, two defines (case issues and typo) causes issues, also commented out a BSD block that causes error (Ubuntu)