### PR TITLE
Fix two macro-related parsing errors

### DIFF
--- a/source/Compiler/parser.cpp
+++ b/source/Compiler/parser.cpp
@@ -570,7 +570,19 @@ void Parser::PreprocessIfDefs(bool ifdef) {
             if (m_currentToken.m_value.startsWith("if")) {
                 ignorePop++;
             }
-            Eat();
+            if (m_currentToken.m_value.toLower() == "macro") {
+                // A macro body is javascript, not TRSE code, so it cannot be
+                // tokenized here. Swallow it in one go like HandleMacro
+                // does, but without registering the macro
+                m_pass = PASS_OTHER; // don't trigger the preprocessor while eating
+                Eat();               // @macro
+                Eat();               // name
+                Eat();               // number of parameters
+                m_currentToken = m_lexer->Macro();
+                Eat(); // the macro body
+                Eat(); // @endmacro
+            } else
+                Eat();
             m_pass = org;
         } else {
             int org = m_pass;

--- a/source/Compiler/parser.cpp
+++ b/source/Compiler/parser.cpp
@@ -5662,7 +5662,7 @@ void Parser::HandleCallMacro(QString name, bool ignore) {
             p += ",";
         }
     }
-    uint pos = m_lexer->m_pos + 1;
+    uint pos = m_lexer->m_pos;
     Eat(TokenType::RPAREN);
     if (m_currentToken.m_type == TokenType::SEMI)
         Eat(TokenType::SEMI);


### PR DESCRIPTION
This pull request fixes two parsing errors in the current version of TRSE:

- When defining a macro within an `@ifdef` that would evaluate as false, the macro code would be attempted to be parsed as TRSE code, when it's JavaScript code, causing parsing errors wherever JS syntax differs from TRSE syntax (such as an opening curly bracket after a for).
- Parsing error when placing the semicolon after a macro call right after its closing parenthesis, i.e. "@MyMacro("Something");". It incorrectly made it required to put a white space between the closing parenthesis and the semicolon.