### PR TITLE
Fix Windows build by updating PATH for windeployqt execution

### DIFF
--- a/.github/workflows/win32-msvc.yml
+++ b/.github/workflows/win32-msvc.yml
@@ -116,6 +116,9 @@ jobs:
             fi
           fi
           echo "windeployqt: '${windeployqt}'"
+          # windeployqt.exe needs its own Qt DLLs in PATH to load; add the Qt
+          # bin dir explicitly since this bash step starts without it.
+          export PATH="${qt_bin_dir}:${PATH}"
           "${windeployqt}" --release --compiler-runtime .
           echo "Copy all required plugins"
           while read plugin


### PR DESCRIPTION
This pull request addresses the issue with the Windows build in GitHub Actions, specifically related to the execution of `windeployqt.exe`. 

### Changes made:
- Added `export PATH="${qt_bin_dir}:${PATH}"` to the workflow file before invoking `windeployqt.exe`. 

### Reason for the change:
- The previous setup did not include the `qt_bin_dir` in the PATH, leading to exit code 127 when attempting to run `windeployqt.exe`. This change ensures that the necessary Qt DLLs are accessible, allowing the binary to load correctly and resolve its dependencies.